### PR TITLE
Add nmap scanning module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ var/
 venv/
 env/
 ENV/
+.venv/
 
 # IDE files
 .idea/

--- a/kit/__init__.py
+++ b/kit/__init__.py
@@ -1,2 +1,7 @@
 """WiFi Marauder plugin modules package."""
-__all__ = ['iface', 'scan']
+
+__all__ = [
+    'iface',
+    'scan',
+    'nmap_scan',
+]

--- a/kit/nmap_scan.py
+++ b/kit/nmap_scan.py
@@ -1,0 +1,43 @@
+"""Run and parse Nmap scans."""
+from __future__ import annotations
+
+import subprocess
+import xml.etree.ElementTree as ET
+from typing import List, Dict, Optional
+
+
+def run_scan(target: str, flags: Optional[str] = "-sV") -> str:
+    """Run nmap scan with *flags* against *target* and return XML output."""
+    cmd = ["nmap"]
+    if flags:
+        cmd.extend(flags.split())
+    cmd += ["-oX", "-", target]
+    try:
+        return subprocess.check_output(cmd, text=True)
+    except Exception as exc:  # pragma: no cover - real binary may not be present
+        raise RuntimeError(f"nmap failed: {exc}")
+
+
+def parse_xml(xml_data: str) -> List[Dict[str, object]]:
+    """Parse nmap XML output and return simplified host results."""
+    hosts: List[Dict[str, object]] = []
+    root = ET.fromstring(xml_data)
+    for host in root.findall("host"):
+        addr = host.find("address")
+        if addr is None:
+            continue
+        ip = addr.get("addr")
+        ports_data = []
+        for port in host.findall("ports/port"):
+            portid = port.get("portid")
+            proto = port.get("protocol")
+            state_el = port.find("state")
+            service_el = port.find("service")
+            ports_data.append({
+                "port": portid,
+                "protocol": proto,
+                "state": state_el.get("state") if state_el is not None else "",
+                "service": service_el.get("name") if service_el is not None else "",
+            })
+        hosts.append({"ip": ip, "ports": ports_data})
+    return hosts

--- a/tests/test_nmap_scan.py
+++ b/tests/test_nmap_scan.py
@@ -1,0 +1,26 @@
+import unittest
+from unittest.mock import patch
+from kit import nmap_scan
+
+class TestNmapScan(unittest.TestCase):
+    def test_run_scan(self):
+        with patch('subprocess.check_output', return_value='<nmaprun></nmaprun>') as mock_co:
+            out = nmap_scan.run_scan('localhost')
+            self.assertIn('<nmaprun>', out)
+            mock_co.assert_called()
+
+    def test_parse_xml(self):
+        sample = '''<nmaprun>
+  <host>
+    <address addr="192.168.0.1" addrtype="ipv4"/>
+    <ports>
+      <port protocol="tcp" portid="80">
+        <state state="open"/>
+        <service name="http"/>
+      </port>
+    </ports>
+  </host>
+</nmaprun>'''
+        res = nmap_scan.parse_xml(sample)
+        self.assertEqual(res[0]['ip'], '192.168.0.1')
+        self.assertEqual(res[0]['ports'][0]['port'], '80')

--- a/wifi_marauder_cli.py
+++ b/wifi_marauder_cli.py
@@ -30,6 +30,12 @@ except ImportError as exc:  # pragma: no cover
     print(json.dumps({"success": False, "error": f"Failed to import OSINT modules: {exc}"}))
     sys.exit(1)
 
+try:
+    from kit import nmap_scan
+except ImportError as exc:  # pragma: no cover
+    print(json.dumps({"success": False, "error": f"Failed to import nmap module: {exc}"}))
+    sys.exit(1)
+
 
 def as_json(data):
     """Print *data* as prettified JSON and exit."""
@@ -84,6 +90,13 @@ def cmd_status(_args):
     })
 
 
+def cmd_nmap_scan(args):
+    """Run an nmap scan and return parsed results."""
+    xml = nmap_scan.run_scan(args.target, flags=args.flags)
+    hosts = nmap_scan.parse_xml(xml)
+    as_json({"success": True, "hosts": hosts})
+
+
 def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(description="WiFi Marauder CLI")
     sub = p.add_subparsers(dest="cmd", required=True)
@@ -116,6 +129,12 @@ def build_parser() -> argparse.ArgumentParser:
 
     # Status
     sub.add_parser("status", help="Show decoy flood status").set_defaults(func=cmd_status)
+
+    # Nmap scan
+    nmap = sub.add_parser("nmap-scan", help="Run nmap scan and return results")
+    nmap.add_argument("target", help="Target host or network")
+    nmap.add_argument("--flags", default="-sV", help="Additional nmap flags")
+    nmap.set_defaults(func=cmd_nmap_scan)
 
     # OSINT – Shodan search
     shodan = sub.add_parser("shodan-search", help="Search Shodan hosts")


### PR DESCRIPTION
## Summary
- include nmap_scan helper
- expose nmap-scan via CLI
- export nmap_scan in kit package
- ignore `.venv/`
- test nmap scanning logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e6757ba60832bb263b176df68843a

## Summary by Sourcery

Add Nmap scanning support by implementing a new kit.nmap_scan module, exposing it via the CLI, updating package exports, and covering it with tests

New Features:
- Introduce kit.nmap_scan module to run and parse Nmap scans
- Expose nmap-scan subcommand in the CLI using kit.nmap_scan
- Export nmap_scan in the kit package

Tests:
- Add unit tests for nmap_scan.run_scan and nmap_scan.parse_xml

Chores:
- Ignore .venv/ in .gitignore