### PR TITLE
Fix WPS import location

### DIFF
--- a/main.py
+++ b/main.py
@@ -97,7 +97,7 @@ except ImportError:
     NFM = None
 
 try:
-    from wps_vulnerability_tester import WPSVulnerabilityTester
+    from wps_vulnerability_logic import WPSVulnerabilityTester
 except ImportError:
     print("Warning: WPSVulnerabilityTester not available. Functionality will be limited.")
     WPSVulnerabilityTester = None


### PR DESCRIPTION
## Summary
- fix import path for WPSVulnerabilityTester

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e75fba9d8832ba2d52b9b4892a073

## Summary by Sourcery

Bug Fixes:
- Correct the import statement for WPSVulnerabilityTester to reference wps_vulnerability_logic instead of wps_vulnerability_tester